### PR TITLE
add go-fuzz test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@
 
 # Others
 vendor/
+
+# go-fuzz
+corpus/
+crashers/
+suppressions/
+*.zip

--- a/frame_lease.go
+++ b/frame_lease.go
@@ -2,11 +2,16 @@ package rsocket
 
 import (
 	"encoding/binary"
+	"fmt"
 	"time"
 )
 
 type frameLease struct {
 	*baseFrame
+}
+
+func (p *frameLease) String() string {
+	return fmt.Sprintf("frameLease{%s,timeToLive=%d,numberOfRequests=%d,metadata=%s}", p.header, p.TimeToLive(), p.NumberOfRequests(), p.Metadata())
 }
 
 func (p *frameLease) TimeToLive() time.Duration {

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,76 @@
+// +build gofuzz
+
+//go:generate GO111MODULE=off go-fuzz-build github.com/rsocket/rsocket-go/
+
+package rsocket
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+func Fuzz(data []byte) int {
+	buf := bytes.NewBuffer(data)
+	decoder := newLengthBasedFrameDecoder(buf)
+
+	err := decoder.handle(func(raw []byte) error {
+		h := parseHeaderBytes(data)
+		bf := borrowByteBuffer()
+		f := &baseFrame{h, bf}
+
+		var frame Frame
+
+		switch f.header.Type() {
+		case tSetup:
+			frame = &frameSetup{f}
+		case tKeepalive:
+			frame = &frameKeepalive{f}
+		case tRequestResponse:
+			frame = &frameRequestResponse{f}
+		case tRequestFNF:
+			frame = &frameFNF{f}
+		case tRequestStream:
+			frame = &frameRequestStream{f}
+		case tRequestChannel:
+			frame = &frameRequestChannel{f}
+		case tCancel:
+			frame = &frameCancel{f}
+		case tPayload:
+			frame = &framePayload{f}
+		case tMetadataPush:
+			frame = &frameMetadataPush{f}
+		case tError:
+			frame = &frameError{f}
+		case tRequestN:
+			frame = &frameRequestN{f}
+		default:
+			return ErrInvalidFrame
+		}
+
+		switch f := frame.(type) {
+		case fmt.Stringer:
+			s := f.String()
+
+			if len(s) > 0 {
+				return nil
+			}
+		case error:
+			e := f.Error()
+
+			if len(e) > 0 {
+				return nil
+			}
+		default:
+			panic("unreachable")
+		}
+
+		return errors.New("???")
+	})
+
+	if err == nil || err == ErrInvalidFrame {
+		return 0
+	}
+
+	return 1
+}


### PR DESCRIPTION
add `fuzz` testing base on [go-fuzz](https://github.com/dvyukov/go-fuzz), and you could reproduce the 11 crashers.

```
$ GO111MODULE=off go-fuzz-build
$ go-fuzz
2019/03/11 21:54:17 workers: 4, corpus: 56 (3s ago), crashers: 11, restarts: 1/0, execs: 0 (0/sec), cover: 0, uptime: 3s
```