### PR TITLE
fixes FireAndForget to execute FF call

### DIFF
--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -88,7 +88,7 @@ func (p AbstractRSocket) MetadataPush(msg payload.Payload) {
 
 // FireAndForget starts a request of FireAndForget.
 func (p AbstractRSocket) FireAndForget(msg payload.Payload) {
-	if p.MP == nil {
+	if p.FF == nil {
 		logger.Errorf("%s\n", errUnsupportedFireAndForget)
 		return
 	}


### PR DESCRIPTION
I think there was a small typo in line 91 of socket.go