### PR TITLE
Add client instance to onconnect function

### DIFF
--- a/rsocket_test.go
+++ b/rsocket_test.go
@@ -633,7 +633,7 @@ func TestContextTimeout(t *testing.T) {
 
 	connected := make(chan bool)
 	cli, err := Connect().
-		OnConnect(func(err error) {
+		OnConnect(func(c Client,err error) {
 			connected <- err == nil
 		}).
 		ConnectTimeout(100 * time.Millisecond).


### PR DESCRIPTION
Add client instance to onconnect function, which can be added to the balancer of rsocket through callback function