### PR TITLE
Add the balancer to return the length method

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -19,4 +19,6 @@ type Balancer interface {
 	Next(context.Context) (rsocket.Client, bool)
 	// OnLeave handle events when a client exit.
 	OnLeave(fn func(label string))
+	//Returns the balancer length
+	Len() int
 }

--- a/balancer/round_robin.go
+++ b/balancer/round_robin.go
@@ -30,6 +30,9 @@ func (b *balancerRoundRobin) OnLeave(fn func(label string)) {
 		b.onLeave = append(b.onLeave, fn)
 	}
 }
+func (b *balancerRoundRobin) Len() int {
+	return len(b.sockets)
+}
 
 func (b *balancerRoundRobin) Put(client rsocket.Client) error {
 	return b.PutLabel(uuid.New().String(), client)

--- a/balancer/round_robin_test.go
+++ b/balancer/round_robin_test.go
@@ -118,6 +118,7 @@ func TestRoundRobin(t *testing.T) {
 	c, ok = b.Next(context.Background())
 	assert.True(t, ok, "get next client failed")
 	_, err = c.RequestResponse(req).Block(context.Background())
+
 	assert.NoError(t, err)
 	total++
 
@@ -129,6 +130,8 @@ func TestRoundRobin(t *testing.T) {
 
 	for i := 0; i < extra; i++ {
 		c, ok = b.Next(context.Background())
+
+
 		assert.True(t, ok, "get next client failed")
 		_, err = c.RequestResponse(req).Block(context.Background())
 		assert.NoError(t, err)
@@ -149,4 +152,5 @@ func TestRoundRobin(t *testing.T) {
 	defer cancel()
 	_, ok = b.Next(ctx)
 	assert.False(t, ok)
+	assert.Equal(t,0,b.Len())
 }


### PR DESCRIPTION
This method is added because the health check needs to obtain whether there is a value in the balancer. Since len (slice) is very fast, it is not locked. If necessary, it can be locked

