### PR TITLE
Adds support for Proxy function specified by the user

### DIFF
--- a/core/transport/websocket_transport.go
+++ b/core/transport/websocket_transport.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -177,16 +178,12 @@ func NewWebsocketServerTransportWithAddr(addr string, path string, upgrader *web
 }
 
 // NewWebsocketClientTransport creates a new client-side transport.
-func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Config, header http.Header) (*Transport, error) {
+func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Config, header http.Header, proxy func(*http.Request) (*url.URL, error)) (*Transport, error) {
 	var dial *websocket.Dialer
-	if config == nil {
-		dial = websocket.DefaultDialer
-	} else {
-		dial = &websocket.Dialer{
-			Proxy:            http.ProxyFromEnvironment,
-			HandshakeTimeout: 45 * time.Second,
-			TLSClientConfig:  config,
-		}
+	dial = &websocket.Dialer{
+		Proxy:            proxy,
+		HandshakeTimeout: 45 * time.Second,
+		TLSClientConfig:  config,
 	}
 	conn, _, err := dial.DialContext(ctx, url, header)
 	if err != nil {

--- a/core/transport/websocket_transport.go
+++ b/core/transport/websocket_transport.go
@@ -179,8 +179,7 @@ func NewWebsocketServerTransportWithAddr(addr string, path string, upgrader *web
 
 // NewWebsocketClientTransport creates a new client-side transport.
 func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Config, header http.Header, proxy func(*http.Request) (*url.URL, error)) (*Transport, error) {
-	var dial *websocket.Dialer
-	dial = &websocket.Dialer{
+	dial := &websocket.Dialer{
 		Proxy:            proxy,
 		HandshakeTimeout: 45 * time.Second,
 		TLSClientConfig:  config,


### PR DESCRIPTION
This PR fixes https://github.com/rsocket/rsocket-go/issues/103.

Default behavior still remains as it is, but the user can override the default Proxy function using the `SetProxy` method.