### PR TITLE
fix: request-channel deadlock in some cases

### DIFF
--- a/rsocket_test.go
+++ b/rsocket_test.go
@@ -357,12 +357,12 @@ func testAll(t *testing.T, proto string, clientTp transport.ClientTransporter, s
 					RequestChannel(func(inputs flux.Flux) flux.Flux {
 						received := new(int32)
 						inputs.
-							DoFinally(func(s rx.SignalType) {
-								assert.Equal(t, channelElements, atomic.LoadInt32(received))
-							}).
 							DoOnNext(func(input payload.Payload) error {
 								atomic.AddInt32(received, 1)
 								return nil
+							}).
+							DoOnComplete(func() {
+								assert.Equal(t, channelElements, atomic.LoadInt32(received))
 							}).
 							Subscribe(context.Background())
 


### PR DESCRIPTION
Fix request-channel deadlock in some cases

### Motivation:

Fix #106 

### Modifications:

Fix the request-channel logic when processing the last complete frame.

### Result:

fixed


