### PR TITLE
Include HTTP error code when gorilla DialContext fails

### DIFF
--- a/core/transport/websocket_transport.go
+++ b/core/transport/websocket_transport.go
@@ -184,9 +184,9 @@ func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Co
 		HandshakeTimeout: 45 * time.Second,
 		TLSClientConfig:  config,
 	}
-	conn, _, err := dial.DialContext(ctx, url, header)
+	conn, resp, err := dial.DialContext(ctx, url, header)
 	if err != nil {
-		return nil, errors.Wrap(err, "dial websocket failed")
+		return nil, errors.Wrapf(err, "dial websocket failed: %s", resp.Status)
 	}
 	return NewTransport(NewWebsocketConnection(conn)), nil
 }


### PR DESCRIPTION
Include HTTP error code when gorilla DialContext fails

### Motivation:

When connection to a WebSocket server fails, we only return the error that we get from the gorilla `DialContext`. This error usually doesn't contain enough information to debug why the connection failed. `DialContext` also returns a non-nil `http.Response`, which contains the HTTP status returned by the server. We should include this HTTP status too in the error being returned back to the user.

### Modifications:

Instead of ignoring the `http.Response` returned by `DialContext`, include the HTTP status from the response in the error.

### Result:

HTTP Error returned by the server is also included in the error returned to the user.

For example: `dial websocket failed: 403 Forbidden: websocket: bad handshake`