### PR TITLE
Check for nil resp before using resp.Status after DialContext error

### DIFF
--- a/core/transport/websocket_transport.go
+++ b/core/transport/websocket_transport.go
@@ -184,9 +184,9 @@ func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Co
 		HandshakeTimeout: 45 * time.Second,
 		TLSClientConfig:  config,
 	}
-	conn, _, err := dial.DialContext(ctx, url, header)
+	conn, resp, err := dial.DialContext(ctx, url, header)
 	if err != nil {
-		return nil, errors.Wrap(err, "dial websocket failed")
+		return nil, errors.Wrapf(err, "dial websocket failed: %s", resp.Status)
 	}
 	return NewTransport(NewWebsocketConnection(conn)), nil
 }

--- a/core/transport/websocket_transport.go
+++ b/core/transport/websocket_transport.go
@@ -186,7 +186,11 @@ func NewWebsocketClientTransport(ctx context.Context, url string, config *tls.Co
 	}
 	conn, resp, err := dial.DialContext(ctx, url, header)
 	if err != nil {
-		return nil, errors.Wrapf(err, "dial websocket failed: %s", resp.Status)
+		if resp != nil {
+			return nil, errors.Wrapf(err, "dial websocket failed: %s", resp.Status)
+		} else {
+			return nil, errors.Wrap(err, "dial websocket failed")
+		}
 	}
 	return NewTransport(NewWebsocketConnection(conn)), nil
 }


### PR DESCRIPTION
Check for nil resp before using resp.Status after DialContext error

### Motivation:

This is a follow-up to the last PR https://github.com/rsocket/rsocket-go/pull/108. Turns out gorilla DialContext can return a `nil` response in some cases. If so, `resp.Status` panics of course.

### Modifications:

Check for non `nil` resp before using `resp.Status`.

### Result:

HTTP response status is included in the error only if there's a non `nil` response from `DialContext`.