### PR TITLE
Update installation instructions to use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
  - Thin [reactive-streams](http://www.reactive-streams.org/) implementation.
  - Simulate Java SDK API.
  - Fast CLI (Compatible with [https://github.com/rsocket/rsocket-cli](https://github.com/rsocket/rsocket-cli/)).
-   - Installation: `go get github.com/rsocket/rsocket-go/cmd/rsocket-cli`
+   - Installation: `go install github.com/rsocket/rsocket-go/cmd/rsocket-cli@latest`
    - Example: `rsocket-cli --request -i hello_world --setup setup_me tcp://127.0.0.1:7878`
 
 ## Install
@@ -23,7 +23,7 @@
 > Minimal go version is ***1.11***.
 
 ```shell
-$ go get -u github.com/rsocket/rsocket-go
+$ go install github.com/rsocket/rsocket-go/cmd/rsocket-cli@latest
 ```
 
 ## Quick Start


### PR DESCRIPTION
Update installation instructions to use go install instead of go get

### Motivation:

go get no longer works and gives the error:

```
% go get github.com/rsocket/rsocket-go
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

### Modifications:

replace `go get` with `go install ... latest` in installation instructions

### Result:

The installation instructions will now be up to date and work again
