### PR TITLE
Fixed processor dispose race condition

### DIFF
--- a/internal/socket/duplex.go
+++ b/internal/socket/duplex.go
@@ -256,11 +256,13 @@ func (dc *DuplexConnection) RequestResponse(req payload.Payload) (res mono.Mono)
 
 	onFinally := func(s reactor.SignalType, d reactor.Disposable) {
 		common.TryRelease(handler.cache)
-		d.Dispose()
 		if s == reactor.SignalTypeCancel {
 			dc.sendFrame(framing.NewWriteableCancelFrame(sid))
 		}
+		// Unregister handler w/sink (processor).
 		dc.unregister(sid)
+		// Dispose sink (processor).
+		d.Dispose()
 	}
 
 	m, s, _ := mono.NewProcessor(dc.reqSche, onFinally)


### PR DESCRIPTION
_Fix race condition in RequestResponse (with processor Dispose())_

### Motivation:

I caught this bug while stress-testing RSocket-based Client/Server implementation in Facebook Thrift: https://github.com/facebook/fbthrift/blob/main/thrift/lib/go/thrift/stress/server_test.go

It's a pretty simple stress test - just 100K concurrent RequestResponse's to 1 server.
At most 100 concurrent RSocket connections at a time, a fresh connection is created for each request.

The symptom of the stress-test failure was that a small portion of requests would fail with `use of closed network connection` error.
```
2024/12/16 15:21:02 flush failed drain: flush failed: write tcp [::1]:43993->[::1]:40658: use of closed network connection
2024/12/16 15:21:02 flush failed drain: flush failed: write tcp [::1]:43993->[::1]:35820: use of closed network connection
2024/12/16 15:21:02 flush failed drain: flush failed: write tcp [::1]:43993->[::1]:36604: use of closed network connection
2024/12/16 15:21:02 flush failed drain: flush failed: write tcp [::1]:43993->[::1]:36780: use of closed network connection
2024/12/16 15:21:02 flush failed drain: flush failed: write tcp [::1]:43993->[::1]:35856: use of closed network connection
```

This is a race condition between two clients and it goes like this:
1. Client makes a `RequestResponse` type of request here:
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L247
2. A `mono` processor is created by pulling it from a global processor pool:
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L266
    * ([Corresponding global pool](https://github.com/jjeffcaii/reactor-go/blob/ac1270f599a9bdbf7506a88059e929656c64e345/mono/initiate.go#L60-L67) code in the `reactor-go` repo.)
3. A callback handler is registered, the processor is assigned to its `sink` field:
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L267-L269
4. The client gets a response back from the server (no issues).
5. The processor invokes the `onFinally` callback (since the Stream Sequence is now complete):
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L257-L264
7. The processor gets disposed on the following line (it is placed back into the global processor pool and becomes available for any other RSocket client to use):
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L259
8.  Immediately after the above line - our current Go-routine gets pre-emptied. It **does not** get a chance to unregister the handler callback (which still holds a pointer to the sink we just released into the global pool):
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L263
9. Another Go-routine starts running.
  a. This Go-routine creates a completely separate RSocket client to make a separate RequestResponse.
  b. This RSocket client happens to get the same sink/processor (that we just disposed earlier) from the global pool.
10. We call `Close()` on our original client from earlier steps (since the RequestResponse sequence had already been completed).
  a. A `destroyHandler` method gets invoked:
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L133-L138
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/duplex.go#L163
  b. It in turn invokes `stopWithError` method of our handler (which we did not yet unregister because we got pre-emptied in step 8):
https://github.com/rsocket/rsocket-go/blob/473989b43c9524185babd293a088cad842e0061a/internal/socket/callback.go#L33-L36
  c. However, the `sink` is already being used by another client. **We are sending Error to a completely unrelated client!!!** Race condition!
  d. The other (unrelated) client gets a false-positive error that the socket is closed!
11. At some point after `Close()` executes, the Go routine from step 8 is scheduled and is finally able to unregister the handler - but it's too late - the race condition already occurred.

### Modifications/Fix:

Correctly ordered the relevant operations to avoid the race condition:
1. Unregister handler callback with its `sink` (i.e. processor) first.
2. Dispose (place back into the global pool) of the sink (processor) last.

### Result:

The stress test succeeds after this change.