### PR TITLE
Fix go 1.18 compatibility

### DIFF
--- a/internal/socket/subscriber_request_response.go
+++ b/internal/socket/subscriber_request_response.go
@@ -3,7 +3,6 @@ package socket
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"github.com/jjeffcaii/reactor-go"
 	"github.com/rsocket/rsocket-go/core"
@@ -11,6 +10,7 @@ import (
 	"github.com/rsocket/rsocket-go/internal/fragmentation"
 	"github.com/rsocket/rsocket-go/payload"
 	"github.com/rsocket/rsocket-go/rx"
+	"go.uber.org/atomic"
 )
 
 var globalRequestResponseSubscriberPool requestResponseSubscriberPool


### PR DESCRIPTION
_Fix go 1.18 compatibility_

### Motivation:

In my earlier PR (https://github.com/rsocket/rsocket-go/pull/137) - I broke `go1.18` compatibility.
(I was not aware this was a requirement for this repo/implementation.)
I used a `sync/atomic` package which is not available until `go1.19`.

### Modifications:

Restoring the compatibility by using an equivalent `go.uber.org/atomic` package, rather than `sync/atomic`.
I see that the rest of the repo is using this package already, and the package is `go1.18` compatible.

### Result:

I am not entirely sure why the linter missed this on the original PR.
But this change should make everything compatible with `go1.18` again.