### PR TITLE
Fix destroy handler race

### DIFF
--- a/internal/socket/duplex.go
+++ b/internal/socket/duplex.go
@@ -161,15 +161,11 @@ func (dc *DuplexConnection) destroyTransport() {
 }
 
 func (dc *DuplexConnection) destroyHandler(err error) {
-	// TODO: optimize callback map
-	var callbacks []callback
 	dc.messages.Range(func(_, value interface{}) bool {
-		callbacks = append(callbacks, value.(callback))
+		cb := value.(callback)
+		cb.stopWithError(err)
 		return true
 	})
-	for _, next := range callbacks {
-		next.stopWithError(err)
-	}
 }
 
 func (dc *DuplexConnection) destroyFragment() {


### PR DESCRIPTION
Fixes a race in `destroyHandler` w.r.t. `dc.messages` sync.Map

### Motivation:

This PR is meant to fix a contributing factor to the following race PR: https://github.com/jjeffcaii/reactor-go/pull/45

In the current implementation of `destroyHandler` - it's possible to call `stopWithError` on a callback that has already been unregistered. This can affect a completely unrelated `Duplex` object (because global pools are used for `processor` objects - and an already "disposed" processor can receive an error).

The race (for example) can occur between the following pieces of code:
https://github.com/rsocket/rsocket-go/blob/099cb5babee5b6e19d9488de5d7ad12f107be5ef/internal/socket/duplex.go#L163-L173
https://github.com/rsocket/rsocket-go/blob/099cb5babee5b6e19d9488de5d7ad12f107be5ef/internal/socket/duplex.go#L257-L266

They both access `dc.messages`. `destroyHandler` - for reading (iteration), `onFinally` - for writing (inside `unregister` method).

In the existing version of `destroyHandler` - by the time iteration (`Range()`) over `dc.messages` is complete - some of the messages may have already been unregistered and removed from the map. This is where the race comes from.

As per documentation: https://pkg.go.dev/sync#Map.Range
> Range does not block other methods on the receiver

-> Meaning that it's totally safe to invoke every callback from inside `Range` - no need to store callbacks in a slice beforehand.

### Modifications:

Perform callback `stopWithError` invocations directly during `Range` iteration, without creating a slice of callbacks beforehand.

### Result:

The issue described in https://github.com/jjeffcaii/reactor-go/pull/45 goes away.
