### PR TITLE
Make operations with global logger thread-safe

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,8 +1,12 @@
 package logger
 
-import "log"
+import (
+	"log"
+	"sync"
+)
 
 var (
+	_mu     sync.RWMutex
 	_level         = LevelInfo
 	_logger Logger = simpleLogger{}
 )
@@ -36,55 +40,73 @@ type Level int8
 // SetLevel set global RSocket log level.
 // Available levels are `LevelDebug`, `LevelInfo`, `LevelWarn` and `LevelError`.
 func SetLevel(level Level) {
+	_mu.Lock()
+	defer _mu.Unlock()
 	_level = level
 }
 
 // SetLogger customize the global logger.
 // A standard log implementation will be used by default.
 func SetLogger(logger Logger) {
+	_mu.Lock()
+	defer _mu.Unlock()
 	_logger = logger
 }
 
 // GetLevel returns current logger level.
 func GetLevel() Level {
+	_mu.RLock()
+	defer _mu.RUnlock()
 	return _level
 }
 
 // IsDebugEnabled returns true if debug level is open.
 func IsDebugEnabled() bool {
+	_mu.RLock()
+	defer _mu.RUnlock()
 	return _level <= LevelDebug
 }
 
 // Debugf prints debug level log.
 func Debugf(format string, args ...interface{}) {
-	if _logger == nil || _level > LevelDebug {
+	logger, level := getLoggerAndLevel()
+	if logger == nil || level > LevelDebug {
 		return
 	}
-	_logger.Debugf(format, args...)
+	logger.Debugf(format, args...)
 }
 
 // Infof prints info level log.
 func Infof(format string, args ...interface{}) {
-	if _logger == nil || _level > LevelInfo {
+	logger, level := getLoggerAndLevel()
+	if logger == nil || level > LevelInfo {
 		return
 	}
-	_logger.Infof(format, args...)
+	logger.Infof(format, args...)
 }
 
 // Warnf prints warn level log.
 func Warnf(format string, args ...interface{}) {
-	if _logger == nil || _level > LevelWarn {
+	logger, level := getLoggerAndLevel()
+	if logger == nil || level > LevelWarn {
 		return
 	}
-	_logger.Warnf(format, args...)
+	logger.Warnf(format, args...)
 }
 
 // Errorf prints error level log.
 func Errorf(format string, args ...interface{}) {
-	if _logger == nil || _level > LevelError {
+	logger, level := getLoggerAndLevel()
+	if logger == nil || level > LevelError {
 		return
 	}
-	_logger.Errorf(format, args...)
+	logger.Errorf(format, args...)
+}
+
+func getLoggerAndLevel() (Logger, Level) {
+	_mu.RLock()
+	defer _mu.RUnlock()
+	return _logger, _level
 }
 
 type simpleLogger struct {


### PR DESCRIPTION
Make operations with global logger thread-safe.

### Motivation:

We have race-conditions when use multiple multiple rsocket servers for tests concurrently.

### Modifications:

Protected variables using RWMutex.

### Result:

It's thread-safe now.
