### PR TITLE
Fix fragmentation bug

### DIFF
--- a/internal/socket/duplex.go
+++ b/internal/socket/duplex.go
@@ -1092,10 +1092,20 @@ func (dc *DuplexConnection) sendPayload(
 	}
 	dc.doSplit(d, m, func(index int, result fragmentation.SplitResult) {
 		flag := result.Flag
+		isLastFragment := !result.Flag.Check(core.FlagFollow)
+
 		if index == 0 {
 			flag |= frameFlag
+			// Remove (C)omplete flag, unless this is the last fragment.
+			if !isLastFragment {
+				flag &^= core.FlagComplete
+			}
 		} else {
 			flag |= core.FlagNext
+			// Set (C)omplete flag, if the original frame had it and this is the last fragment.
+			if isLastFragment && frameFlag.Check(core.FlagComplete) {
+				flag |= core.FlagComplete
+			}
 		}
 
 		// lazy release at last frame


### PR DESCRIPTION
Fix fragmentation bug in final frame

### Motivation:

If the final frame of a stream is fragmented - only the last fragment should have the (C)omplete flag set.
Currently - the first fragment has the (C)omplete flag set - which is a bug - because a receiver may assume that the stream is complete even though more fragments are coming.

(F) and (C) flags are essentially mutually exclusive.

### Modifications:

Ensure (C)omplete flag is unset for all fragments besides the last one (i.e. fragments with (F)ollow flag set).

### Result:

The logic now handles the (C)omplete flag correctly for fragmented frames.