### PR TITLE
Support Next/Complete payloads

### DIFF
--- a/internal/socket/subscriber_request_channel.go
+++ b/internal/socket/subscriber_request_channel.go
@@ -12,6 +12,26 @@ import (
 	"go.uber.org/atomic"
 )
 
+// FinalPayload is a marker interface for payloads that should be sent with FlagNext|FlagComplete.
+type FinalPayload interface {
+	payload.Payload
+	IsFinal() bool
+}
+
+// finalPayloadWrapper wraps a payload and marks it as final.
+type finalPayloadWrapper struct {
+	payload.Payload
+}
+
+func (f finalPayloadWrapper) IsFinal() bool {
+	return true
+}
+
+// NewFinalPayload creates a final payload that will be sent with FlagNext|FlagComplete.
+func NewFinalPayload(p payload.Payload) payload.Payload {
+	return finalPayloadWrapper{Payload: p}
+}
+
 type requestChannelSubscriber struct {
 	sid uint32
 	dc  *DuplexConnection
@@ -52,15 +72,22 @@ func (r *requestChannelSubscriber) OnSubscribe(ctx context.Context, s rx.Subscri
 }
 
 type respondChannelSubscriber struct {
-	sid        uint32
-	n          uint32
-	dc         *DuplexConnection
-	rcv        flux.Processor
-	subscribed chan<- struct{}
-	calls      *atomic.Int32
+	sid           uint32
+	n             uint32
+	dc            *DuplexConnection
+	rcv           flux.Processor
+	subscribed    chan<- struct{}
+	calls         *atomic.Int32
+	sentFinalNext atomic.Bool
 }
 
 func (r *respondChannelSubscriber) OnNext(next payload.Payload) {
+	if _, ok := next.(FinalPayload); ok {
+		r.sentFinalNext.Store(true)
+		r.OnComplete()
+		r.dc.sendPayload(r.sid, next, core.FlagNext|core.FlagComplete)
+		return
+	}
 	r.dc.sendPayload(r.sid, next, core.FlagNext)
 }
 
@@ -74,6 +101,9 @@ func (r *respondChannelSubscriber) OnError(err error) {
 func (r *respondChannelSubscriber) OnComplete() {
 	if r.calls.Inc() == 2 {
 		r.dc.unregister(r.sid)
+	}
+	if r.sentFinalNext.Load() {
+		return
 	}
 	complete := framing.NewWriteablePayloadFrame(r.sid, nil, nil, core.FlagComplete)
 	done := make(chan struct{})

--- a/rsocket.go
+++ b/rsocket.go
@@ -86,6 +86,11 @@ func NewAbstractSocket(opts ...OptAbstractSocket) RSocket {
 	return sk
 }
 
+// NewFinalPayload is a wrapper/marker that allows a payload to be sent with both Next and Complete flags.
+func NewFinalPayload(p payload.Payload) payload.Payload {
+	return socket.NewFinalPayload(p)
+}
+
 // MetadataPush register request handler for MetadataPush.
 func MetadataPush(fn func(request payload.Payload)) OptAbstractSocket {
 	return func(socket *socket.AbstractRSocket) {


### PR DESCRIPTION
Support sending a payload with both Next and Complete flags.

### Motivation:

Currently - it's impossible to send a payload with both Next and Complete flags when using RequestChannel subscriber.
`OnNext` callback sends the payload with Next flag, and `OnComplete` payload sends an empty payload with a Complete flag.
But that's two separate payloads, not one.

Setting both Next and Complete flags on the final payload is totally valid (as per [RSocket spec](https://rsocket.io/about/protocol/#payload-frame-0x0a)).

And some implementations (such as Thrift RSocket in C++) in fact require the ability to set both Next and Complete flags on a payload for certain use cases:
https://github.com/facebook/fbthrift/blob/8679ad11edc2a79afa602a55ac4839c524ca36e0/thrift/lib/cpp2/transport/rocket/client/RocketClient.cpp#L699-L700 

### Modifications:

Add a `FinalPayload` wrapper and some simple logic to allow the user to send a payload with both Next and Complete flags.
The behavior is equivalent to calling `OnNext` and `OnComplete`, but only one payload is sent.

### Result:

The modification allows for interoperability of `rsocket-go` with other rsocket implementations and removed the limitation on Next/Complete flags being set on a payload.
