### PR TITLE
Fix response channel error handling

### DIFF
--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -321,7 +321,7 @@ func (p *Transport) DispatchFrame(_ context.Context, frame core.BufferedFrame) (
 	// trigger handler
 	err = handler(frame)
 	if err != nil {
-		err = errors.Wrap(err, fmt.Sprintf("handle frame %s failed:", frame.Header().Type()))
+		err = errors.Wrap(err, fmt.Sprintf("handle frame %s failed:", t))
 	}
 	return
 }

--- a/internal/socket/duplex.go
+++ b/internal/socket/duplex.go
@@ -888,6 +888,8 @@ func (dc *DuplexConnection) onFrameError(input core.BufferedFrame) error {
 		vv.pc.Error(err)
 	case requestChannelCallback:
 		vv.rcv.Error(err)
+	case respondChannelCallback:
+		vv.rcv.Error(err)
 	default:
 		return errors.Errorf("illegal value for error: %v", vv)
 	}


### PR DESCRIPTION
Handle "Error from Requester, Responder terminates" case

### Motivation:

Support and handle the following case for REQUEST_CHANNEL: https://rsocket.io/about/protocol/#error-from-requester-responder-terminates

i.e. when requester sends an ERROR frame to the responder

### Modifications:

Added a missing `case` to the `switch` in `onFrameError` function.

Also - small nit - simplify error message in `DispatchFrame` by referencing a local `t` variable containing frame type. 

### Result:

"Error from Requester, Responder terminates" works correctly after this change.